### PR TITLE
Update to 0.9.1 cgmath, Aabb3 vs Ray

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ name = "collision"
 
 [dependencies]
 num = "0.1"
-cgmath = "0.8"
+cgmath = "0.9.1"

--- a/src/aabb.rs
+++ b/src/aabb.rs
@@ -22,13 +22,12 @@
 
 use std::fmt;
 
-use cgmath::Array;
-use cgmath::{Point, Point2, Point3};
-use cgmath::{Vector, Vector2, Vector3};
+use cgmath::{EuclideanSpace, Point2, Point3};
+use cgmath::{VectorSpace, InnerSpace, Array, Vector2, Vector3};
 use cgmath::{Zero, One};
 use cgmath::{BaseNum, BaseFloat, ElementWise};
 
-use {Ray2, Plane};
+use {Ray2, Ray3, Plane};
 use bound::{Bound, Relation};
 use intersect::Intersect;
 
@@ -75,7 +74,7 @@ impl<S> MinMax for Point3<S>
     }
 }
 
-pub trait Aabb<S: BaseNum, V: Vector<Scalar=S> + ElementWise, P: Point<Scalar=S, Vector=V>>: Sized {
+pub trait Aabb<S: BaseNum, V: VectorSpace<Scalar=S> + ElementWise + Array<Element=S>, P: EuclideanSpace<Scalar=S, Diff=V>>: Sized {
     /// Create a new AABB using two points as opposing corners.
     fn new(p1: P, p2: P) -> Self;
 
@@ -279,6 +278,56 @@ impl<S: BaseFloat> Intersect<Option<Point2<S>>> for (Ray2<S>, Aabb2<S>) {
             else {
                 Some(Point2::new(ray.origin.x + ray.direction.x * tmax,
                                  ray.origin.y + ray.direction.y * tmax))
+            }
+        }
+        else {
+            None
+        }
+    }
+}
+
+
+impl<S: BaseFloat> Intersect<Option<Point3<S>>> for (Ray3<S>, Aabb3<S>) {
+    fn intersection(&self) -> Option<Point3<S>> {
+        let (ref ray, ref aabb) = *self;
+
+        let mut tmin = S::neg_infinity();
+        let mut tmax = S::infinity();
+
+        if ray.direction.x != S::zero() {
+            let tx1 = (aabb.min.x - ray.origin.x) / ray.direction.x;
+            let tx2 = (aabb.max.x - ray.origin.x) / ray.direction.x;
+            tmin = tmin.max(tx1.min(tx2));
+            tmax = tmax.min(tx1.max(tx2));
+        }
+
+        if ray.direction.y != S::zero() {
+            let ty1 = (aabb.min.y - ray.origin.y) / ray.direction.y;
+            let ty2 = (aabb.max.y - ray.origin.y) / ray.direction.y;
+            tmin = tmin.max(ty1.min(ty2));
+            tmax = tmax.min(ty1.max(ty2));
+        }
+
+        if ray.direction.z != S::zero() {
+            let tz1 = (aabb.min.z - ray.origin.z) / ray.direction.z;
+            let tz2 = (aabb.max.z - ray.origin.z) / ray.direction.z;
+            tmin = tmin.max(tz1.min(tz2));
+            tmax = tmax.min(tz1.max(tz2));
+        }
+
+        if tmin < S::zero() && tmax < S::zero() {
+            None
+        }
+        else if tmax >= tmin {
+            if tmin >= S::zero() {
+                Some(Point3::new(ray.origin.x + ray.direction.x * tmin,
+                                 ray.origin.y + ray.direction.y * tmin,
+                                 ray.origin.z + ray.direction.z * tmin))
+            }
+            else {
+                Some(Point3::new(ray.origin.x + ray.direction.x * tmax,
+                                 ray.origin.y + ray.direction.y * tmax,
+                                 ray.origin.z + ray.direction.z * tmax))
             }
         }
         else {

--- a/src/bound.rs
+++ b/src/bound.rs
@@ -18,7 +18,7 @@
 use Plane;
 use cgmath::{Matrix4};
 use cgmath::BaseFloat;
-use cgmath::{Point, Point3};
+use cgmath::{EuclideanSpace, Point3};
 
 /// Spatial relation between two objects.
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialOrd, PartialEq)]

--- a/src/frustum.rs
+++ b/src/frustum.rs
@@ -21,7 +21,7 @@ use cgmath::{zero, one};
 use cgmath::{Matrix, Matrix4};
 use cgmath::BaseFloat;
 use cgmath::Point3;
-use cgmath::{EuclideanVector};
+use cgmath::{EuclideanSpace};
 use cgmath::{Angle, PerspectiveFov, Ortho, Perspective};
 
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/src/intersect.rs
+++ b/src/intersect.rs
@@ -14,9 +14,9 @@
 // limitations under the License.
 
 use {Ray2, Ray3, Plane, Line2};
-use cgmath::{BaseFloat, Zero, EuclideanVector};
-use cgmath::{Point, Point2, Point3};
-use cgmath::{Vector, Vector2};
+use cgmath::{BaseFloat, Zero, EuclideanSpace};
+use cgmath::{Point2, Point3};
+use cgmath::{VectorSpace, InnerSpace, Vector2};
 
 pub trait Intersect<Result> {
     fn intersection(&self) -> Result;

--- a/src/line.rs
+++ b/src/line.rs
@@ -18,8 +18,8 @@
 use std::marker::PhantomData;
 
 use cgmath::{BaseNum};
-use cgmath::{Point, Point2, Point3};
-use cgmath::{Vector, Vector2, Vector3};
+use cgmath::{EuclideanSpace, Point2, Point3};
+use cgmath::{VectorSpace, InnerSpace, Vector2, Vector3};
 
 /// A generic directed line segment from `origin` to `dest`.
 #[derive(Copy, Clone, PartialEq)]
@@ -30,7 +30,7 @@ pub struct Line<S, V, P> {
     phantom_v: PhantomData<V>
 }
 
-impl<S: BaseNum, V: Vector<Scalar=S>, P: Point<Scalar=S, Vector=V>>  Line<S, V, P> {
+impl<S: BaseNum, V: VectorSpace<Scalar=S>, P: EuclideanSpace<Scalar=S, Diff=V>>  Line<S, V, P> {
     pub fn new(origin: P, dest: P) -> Line<S, V, P> {
         Line {
             origin: origin,

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -17,9 +17,9 @@ use std::fmt;
 
 use cgmath::one;
 use cgmath::{ApproxEq, BaseFloat};
-use cgmath::{Point, Point3};
+use cgmath::{Point3};
 use cgmath::{Vector3, Vector4};
-use cgmath::{Vector, EuclideanVector};
+use cgmath::{VectorSpace, EuclideanSpace, InnerSpace};
 
 
 /// A 3-dimensional plane formed from the equation: `A*x + B*y + C*z - D = 0`.
@@ -81,7 +81,7 @@ impl<S: BaseFloat> Plane<S> {
         // find the normal vector that is perpendicular to v1 and v2
         let n = v0.cross(v1);
 
-        if n.approx_eq(&Vector::zero()) { None }
+        if n.approx_eq(&VectorSpace::zero()) { None }
         else {
             // compute the normal and the distance to the plane
             let n = n.normalize();
@@ -99,7 +99,7 @@ impl<S: BaseFloat> Plane<S> {
 
     /// Normalize a plane.
     pub fn normalize(&self) -> Option<Plane<S>> {
-        if self.n.approx_eq(&Vector::zero()) { None }
+        if self.n.approx_eq(&VectorSpace::zero()) { None }
         else {
             let denom = one::<S>() / self.n.magnitude();
             Some(Plane::new(self.n * denom, self.d*denom))

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -15,8 +15,8 @@
 
 use std::marker::PhantomData;
 use cgmath::BaseNum;
-use cgmath::{Point, Point2, Point3};
-use cgmath::{Vector, Vector2, Vector3};
+use cgmath::{EuclideanSpace, Point2, Point3};
+use cgmath::{VectorSpace, Vector2, Vector3};
 
 /// A generic ray starting at `origin` and extending infinitely in
 /// `direction`.
@@ -29,8 +29,8 @@ pub struct Ray<S, P, V> {
 
 impl<S, V, P> Ray<S, P, V>
     where S: BaseNum,
-          V: Vector<Scalar=S>,
-          P: Point<Scalar=S, Vector=V>
+          V: VectorSpace<Scalar=S>,
+          P: EuclideanSpace<Scalar=S, Diff=V>
 {
     pub fn new(origin: P, direction: V) -> Ray<S, P, V> {
         Ray {

--- a/src/sphere.rs
+++ b/src/sphere.rs
@@ -19,9 +19,8 @@ use bound::*;
 use intersect::Intersect;
 use Plane;
 use Ray3;
-use cgmath::{BaseFloat, Zero, EuclideanVector};
-use cgmath::{Point, Point3};
-use cgmath::Vector;
+use cgmath::{BaseFloat, Zero, EuclideanSpace};
+use cgmath::{VectorSpace, InnerSpace, Point3};
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Sphere<S: BaseFloat> {


### PR DESCRIPTION
Mainly just replaces `Vector` and `Point` traits with the `EuclideanSpace` and `VectorSpace` traits.

Kept the `Aabb` raycasting similar to the 2 dimensional one for consistencies sake. Should work fine, tested it [here](https://github.com/Aceeri/overseer-build/blob/master/src/world/chunk.rs#L290).